### PR TITLE
Fix: clear easing hit region when deleting the next key

### DIFF
--- a/automation/easing/Easing.cpp
+++ b/automation/easing/Easing.cpp
@@ -166,6 +166,8 @@ Point<float> CubicEasing::getRawValue(const float& weight)
 
 float CubicEasing::getBezierWeight(const float& pos)
 {
+	if (length == 0) return 0;
+	
 	const int precision = length * 30;
 	float closestT = getWeightForPos(pos);
 	float minDist = INT32_MAX;

--- a/automation/easing/ui/EasingUI.cpp
+++ b/automation/easing/ui/EasingUI.cpp
@@ -71,6 +71,7 @@ void EasingUI::resized()
 void EasingUI::generatePath()
 {
 	drawPath.clear();
+	hitPath.clear();
 
 	if (getHeight() == 0 || getWidth() == 0) return;
 


### PR DESCRIPTION
Without this change, it is possible to hit an outdated easing UI, leading
to data corruption and UI bugs