### PR TITLE
Add getSelectedObject and getSelectedObjectsCount script functions to util object

### DIFF
--- a/script/ScriptUtil.cpp
+++ b/script/ScriptUtil.cpp
@@ -47,6 +47,9 @@ ScriptUtil::ScriptUtil() :
 	scriptObject.setMethod("showMessageBox", ScriptUtil::showMessageBox);
 	scriptObject.setMethod("showOkCancelBox", ScriptUtil::showOkCancelBox);
 	scriptObject.setMethod("showYesNoCancelBox", ScriptUtil::showYesNoCancelBox);
+
+	scriptObject.setMethod("getSelectedObject", ScriptUtil::getSelectedObjectFromScript);
+	scriptObject.setMethod("getSelectedObjectsCount", ScriptUtil::getSelectedObjectsCountFromScript);
 }
 
 var ScriptUtil::getTime(const var::NativeFunctionArgs &)
@@ -558,4 +561,32 @@ var ScriptUtil::base64_decode_bytes(const String& data)
 		}
 	}
 	return result;
+}
+
+var ScriptUtil::getSelectedObjectFromScript(const var::NativeFunctionArgs& args)
+{
+	BaseItem* item = nullptr;
+
+	if (args.numArguments > 0)
+	{
+		Array<BaseItem*> items = InspectableSelectionManager::activeSelectionManager->getInspectablesAs<BaseItem>();
+		int num = args.arguments[0];
+		if (num >= 0 && num < items.size())
+		{
+			item = items[num];
+		}
+	}
+	else
+	{
+		item = InspectableSelectionManager::activeSelectionManager->getInspectableAs<BaseItem>();
+	}
+
+	if(item) return item->getScriptObject();
+
+	return var();
+}
+
+var ScriptUtil::getSelectedObjectsCountFromScript(const var::NativeFunctionArgs& args)
+{
+	return InspectableSelectionManager::activeSelectionManager->getInspectablesAs<BaseItem>().size();
 }

--- a/script/ScriptUtil.h
+++ b/script/ScriptUtil.h
@@ -60,4 +60,7 @@ public:
 	static std::string base64_encode(unsigned char const* src, unsigned int len);
 	static std::string base64_decode(std::string const& data);
 	static var base64_decode_bytes(const String & data);
+
+	static var getSelectedObjectFromScript(const var::NativeFunctionArgs& args);
+	static var getSelectedObjectsCountFromScript(const var::NativeFunctionArgs& args);
 };


### PR DESCRIPTION
This PR is adding 2 functions to the scripting API.
Here's an example of how to use them:
```Javascript
var cnt = util.getSelectedObjectsCount();
script.log("Selected items: " + cnt);

for(var i=0; i<cnt; i++)
{
	script.log("Item #" + i + " type: " + util.getSelectedObject(i).getType());
}
```

The `getSelectedObject()` function can also be used without an argument to get the first selected item.

An example use case in Chataigne:
```Javascript
var item = util.getSelectedObject();
if(item.getType() == "Key"){
	item.value.set(item.value.get()+0.1);
}
```
moves the currently selected key in the Time machine and adds 0.1 to its value, which is useful to bind to a keyboard key for example for precise value editing (I'm surprised it's not a built-in functionality by the way).