### PR TITLE
Make type consistent for feedback and uiFeedback

### DIFF
--- a/dashboard/DashboardManager.cpp
+++ b/dashboard/DashboardManager.cpp
@@ -397,7 +397,12 @@ void DashboardManager::itemDataFeedback(var data)
 #if ORGANICUI_USE_WEBSERVER
 	if (server != nullptr)
 	{
-		data.getDynamicObject()->setProperty("dataType", "feedback");
+		String t = data.getDynamicObject()->getProperty("type");
+		
+		if (t != "uiFeedback") {
+			data.getDynamicObject()->setProperty("type", "feedback");
+		}
+
 		server->send(JSON::toString(data));
 	}
 #endif


### PR DESCRIPTION
Before this commit "feedback" data contained: dataType: "feedback"
After this commit "feedback" data contains: dataType: "Float", type: "feedback"