### PR TITLE
Add save logs parameter

### DIFF
--- a/logger/CustomLogger.cpp
+++ b/logger/CustomLogger.cpp
@@ -3,11 +3,7 @@ juce_ImplementSingleton(CustomLogger);
 CustomLogger::CustomLogger() :
 	notifier(2000, false),
 	welcomeMessage(getApp().getApplicationName() + " v" + String(ProjectInfo::versionString) + " : (" + String(Time::getCompilationDate().formatted("%d/%m/%y (%R)")) + ")")
- {
-	
-#if USE_FILE_LOGGER
-	addLogListener(&fileWriter);
-#endif
+{
 
 }
 
@@ -22,9 +18,20 @@ void CustomLogger::logMessage(const String& message)
 	DBG(message);
 }
 
-#if USE_FILE_LOGGER
+void CustomLogger::setFileLogging(bool enabled)
+{
+	if(enabled && !fileWriter){
+		fileWriter.reset(new CustomLogger::FileWriter());
+		addLogListener(fileWriter.get());
+	}
+	else if(fileWriter)
+	{
+		removeLogListener(fileWriter.get());
+		fileWriter.reset();
+	}
+}
+
 CustomLogger::FileWriter::FileWriter() 
 {
-	fileLog.reset(FileLogger::createDefaultAppLogger(getApp().getApplicationName(), "log", ""));
+	fileLog.reset(FileLogger::createDateStampedLogger(getApp().getApplicationName(), "log_", ".txt", ""));
 }
-#endif

--- a/logger/CustomLogger.h
+++ b/logger/CustomLogger.h
@@ -1,10 +1,6 @@
 
 #pragma once
 
- // do not use file logger atm
- // TODO figure out true utility of such
-#define USE_FILE_LOGGER 0
-
 class CustomLogger : public Logger
 {
 public:
@@ -22,7 +18,8 @@ public:
 	void addLogListener(Listener* l) { notifier.addListener(l); }
 	void removeLogListener(Listener* l) { notifier.removeListener(l); }
 
-#if USE_FILE_LOGGER
+	void setFileLogging(bool enabled);
+
 	class FileWriter : public Listener
 	{
 	public:
@@ -33,8 +30,7 @@ public:
 		std::unique_ptr<FileLogger> fileLog;
 	};
 
-	FileWriter fileWriter;
-#endif
+	std::unique_ptr<FileWriter> fileWriter;
 
 private:
 	const String welcomeMessage;

--- a/settings/GlobalSettings.cpp
+++ b/settings/GlobalSettings.cpp
@@ -55,6 +55,7 @@ GlobalSettings::GlobalSettings() :
 	compressOnSave = saveLoadCC.addBoolParameter("Compress file", "If checked, the JSON content will be minified, otherwise it will be human-readable but larger size as well", true);
 	enableCrashUpload = saveLoadCC.addBoolParameter("Enable Crash Upload", "If checked and a crashlog is found at startup, it will automatically upload it.\nThis crash log is a very small file but is immensely helpful for me, so please leave this option enabled unless you strongly feel like not helping me :)", true);
 	testCrash = saveLoadCC.addTrigger("Test crash", "This will cause a crash, allowing for testing crashes. Don't push this unless you REALLY want to !!!");
+	saveLogsToFile = saveLoadCC.addBoolParameter("Save logs", "If checked, the content of the Logger will be automatically saved to a file", false);
 	addChildControllableContainer(&saveLoadCC);
 
 	askBeforeRemovingItems = editingCC.addBoolParameter("Ask before removing items", "If enabled, you will get a confirmation prompt before removing any item", false);
@@ -109,6 +110,10 @@ void GlobalSettings::onControllableFeedbackUpdate(ControllableContainer * cc, Co
 		Controllable* crashC = nullptr;
 		crashC->getJSONData(); //this will crash
 #endif
+	}
+	else if (c == saveLogsToFile)
+	{
+		CustomLogger::getInstance()->setFileLogging(saveLogsToFile->boolValue());
 	}
 
 	if (Engine::mainEngine != nullptr) Engine::mainEngine->setChangedFlag(false); //force no need to save when changing something in global settings

--- a/settings/GlobalSettings.h
+++ b/settings/GlobalSettings.h
@@ -60,6 +60,7 @@ public:
 
 	BoolParameter* compressOnSave;
 	BoolParameter* enableCrashUpload;
+	BoolParameter* saveLogsToFile;
 
 	ControllableContainer editingCC;
 	BoolParameter * askBeforeRemovingItems;


### PR DESCRIPTION
**Suggestion:**
Add a "Save logs" option to automatically save the content of the logger to a file
![image](https://user-images.githubusercontent.com/21125429/152794464-4259bb9d-f6b4-4ba2-a46e-2be48fc261f3.png)

The logs are saved by default in:
 * C:\Users\username\Application Data\[AppName]\[logFileName] on Windows
 * ~/Library/Logs/[AppName]/[logFileName] on MacOs
 * ~/.config/[AppName]/[logFileName]

The file name format is log_[datestamp].txt (a new file is created each time the software is started or when the option is enabled)
 
This option can be useful to debug autonomous installations.
 
Feel free to give me suggestions if you'd prefer another file name format or another way to implement that.