### PR TITLE
fix ControllableContainer::getControlAddressFromScript reference parameter

### DIFF
--- a/controllable/ControllableContainer.cpp
+++ b/controllable/ControllableContainer.cpp
@@ -1423,7 +1423,7 @@ var ControllableContainer::getControlAddressFromScript(const juce::var::NativeFu
 	ControllableContainer* ref = nullptr;
 	if (a.numArguments > 0 && a.arguments[0].isObject())
 	{
-		if (DynamicObject* d = a.thisObject.getDynamicObject())
+		if (DynamicObject* d = a.arguments[0].getDynamicObject())
 		{
 			ref = dynamic_cast<ControllableContainer*>((ControllableContainer*)(int64)d->getProperty(scriptPtrIdentifier));
 		}


### PR DESCRIPTION
"reference" was ignored, using "this" instead, then the function always returns an empty string if using with a parameter.