### PR TITLE
added dynamic library functions

### DIFF
--- a/script/ScriptUtil.h
+++ b/script/ScriptUtil.h
@@ -69,6 +69,10 @@ public:
 	static var showOkCancelBox(const var::NativeFunctionArgs& args);
 	static var showYesNoCancelBox(const var::NativeFunctionArgs& args);
 
+	static var loadDynamicLibrary(const var::NativeFunctionArgs& args);
+	static var unloadDynamicLibrary(const var::NativeFunctionArgs& args);
+	static var findFunctionInDynamicLibrary(const var::NativeFunctionArgs& args);
+
 
 	//Helpers
 


### PR DESCRIPTION
TLTR: it adds a basic C++ plugin system to Chataigne.

It relies heavily on existing features: custom modules and Javascript. A custom module can use new functions:
```
var dynamicLibrary = util.loadDynamicLibrary("filePath");
var func = util.findFunctionInDynamicLibrary(dynamicLibrary, "functionName");
func();
util.unloadDynamicLibrary(dynamicLibrary);
```

A Chataigne dynamic library is a JUCE dynamic library with any number of exported functions. An exported function signature looks like a script function signature `(const var::NativeFunctionArgs&) -> juce::var`.
A sample can be found here: https://github.com/monsieurgustav/Chataigne-sample-module-dynamic-library

You'll see that it is actually a little bit more complex than that actually: a JUCE project links statically with JUCE. In our case, both Chataigne and the dynamic library link with juce_core. Then all global/static variables are actually duplicated in memory. To mitigate this issue, essential data must be copied from the host Chataigne to the dynamic library.

Alternatives approaches are:
- make a DLL (containing JUCE code) shared between Chataigne and dynamic libraries,
- do not use Javascript objects but make a simple communication interface to retrieve/return values generically with no global/static data.

In the meantime, it adds a way to embed computation heavy/complex code inside Chataigne, which seems interesting enough.