### PR TITLE
Add support for float colours in ColorParameter

### DIFF
--- a/controllable/ControllableContainer.cpp
+++ b/controllable/ControllableContainer.cpp
@@ -1373,26 +1373,25 @@ var ControllableContainer::addColorParameterFromScript(const var::NativeFunction
 	if (args.arguments[2].isArray())
 	{
 		color = args.arguments[2];
-		while (color.size() < 4) color.append(color.size() < 3 ? 0 : 1);
-		for (int i = 0; i < color.size(); ++i) color[i] = (float)color[i] * 255;
+		while (color.size() < 4) color.append(color.size() < 3 ? 0.f : 1.f);
 	}
 	else if (args.numArguments >= 5)
 	{
-		color.append((float)args.arguments[2] * 255);
-		color.append((float)args.arguments[3] * 255);
-		color.append((float)args.arguments[4] * 255);
-		color.append((float)args.numArguments >= 6 ? (float)args.arguments[5] * 255 : 255);
+		color.append((float)args.arguments[2]);
+		color.append((float)args.arguments[3]);
+		color.append((float)args.arguments[4]);
+		color.append((float)args.numArguments >= 6 ? (float)args.arguments[5] : 1.f);
 	}
 	else if (args.arguments[2].isInt() || args.arguments[2].isInt64())
 	{
-		color.append(((int)args.arguments[2] >> 24) & 0xFF);
-		color.append(((int)args.arguments[2] >> 16) & 0xFF);
-		color.append(((int)args.arguments[2] >> 8) & 0xFF);
-		color.append(((int)args.arguments[2]) & 0xFF);
+		color.append((float)(((int)args.arguments[2] >> 24) & 0xFF) / 255.f);
+		color.append((float)(((int)args.arguments[2] >> 16) & 0xFF) / 255.f);
+		color.append((float)(((int)args.arguments[2] >> 8) & 0xFF) / 255.f);
+		color.append((float)(((int)args.arguments[2]) & 0xFF) / 255.f);
 	}
 
 
-	Parameter* p = cc->addColorParameter(args.arguments[0], args.arguments[1], Colour((uint8)(int)color[0], (uint8)(int)color[1], (uint8)(int)color[2], (uint8)(int)color[3]));
+	Parameter* p = cc->addColorParameter(args.arguments[0], args.arguments[1], Colour((float)color[0], (float)color[1], (float)color[2], (float)color[3]));
 	p->isCustomizableByUser = true;
 	return p->getScriptObject();
 }

--- a/controllable/ControllableContainer.cpp
+++ b/controllable/ControllableContainer.cpp
@@ -1391,7 +1391,7 @@ var ControllableContainer::addColorParameterFromScript(const var::NativeFunction
 	}
 
 
-	Parameter* p = cc->addColorParameter(args.arguments[0], args.arguments[1], Colour((float)color[0], (float)color[1], (float)color[2], (float)color[3]));
+	Parameter* p = cc->addColorParameter(args.arguments[0], args.arguments[1], Colour::fromFloatRGBA((float)color[0], (float)color[1], (float)color[2], (float)color[3]));
 	p->isCustomizableByUser = true;
 	return p->getScriptObject();
 }

--- a/controllable/parameter/ColorParameter.cpp
+++ b/controllable/parameter/ColorParameter.cpp
@@ -48,7 +48,7 @@ const Colour ColorParameter::getColor()
 	if (!value.isArray()) return Colours::black;
 	while (value.size() < 4) value.append(0);
 
-	return Colour((uint8)((float)value[0]*255), (uint8)((float)value[1]*255), (uint8)((float)value[2]*255), (uint8)((float)value[3]*255));
+	return Colour::fromFloatRGBA((float)value[0], (float)value[1], (float)value[2], (float)value[3]);
 }
 
 void ColorParameter::setFloatRGBA(const float & r, const float & g, const float & b, const float & a)

--- a/controllable/parameter/ColorParameter.cpp
+++ b/controllable/parameter/ColorParameter.cpp
@@ -12,8 +12,7 @@
 
 
 ColorParameter::ColorParameter(const String & niceName, const String & description, const Colour & initialColor, bool enabled) :
-	Parameter(COLOR,niceName,description,var(),var(),var(),enabled),
-	mode(FLOAT)
+	Parameter(COLOR,niceName,description,var(),var(),var(),enabled)
 {
 	//lockManualControlMode = true;
 
@@ -24,27 +23,17 @@ ColorParameter::ColorParameter(const String & niceName, const String & descripti
 	for (int i = 0; i < 4; ++i)
 	{
 		minVal.append(0);
-		maxVal.append(mode == FLOAT ? 1.0f : 255);
+		maxVal.append(1.0f);
 	}
 
 	minimumValue = minVal;
 	maximumValue = maxVal;
 
 	defaultValue = var();
-	if (mode == FLOAT)
-	{
-		defaultValue.append(initialColor.getFloatRed());
-		defaultValue.append(initialColor.getFloatGreen());
-		defaultValue.append(initialColor.getFloatBlue());
-		defaultValue.append(initialColor.getFloatAlpha());
-	}
-	else
-	{
-		defaultValue.append(initialColor.getRed());
-		defaultValue.append(initialColor.getGreen());
-		defaultValue.append(initialColor.getBlue());
-		defaultValue.append(initialColor.getAlpha());
-	}
+	defaultValue.append(initialColor.getFloatRed());
+	defaultValue.append(initialColor.getFloatGreen());
+	defaultValue.append(initialColor.getFloatBlue());
+	defaultValue.append(initialColor.getFloatAlpha());
 
 	value = defaultValue.clone();
 
@@ -59,8 +48,7 @@ const Colour ColorParameter::getColor()
 	if (!value.isArray()) return Colours::black;
 	while (value.size() < 4) value.append(0);
 
-	if (mode == FLOAT) return Colour((uint8)((float)value[0]*255), (uint8)((float)value[1]*255), (uint8)((float)value[2]*255), (uint8)((float)value[3]*255));
-	else return Colour((uint8)(int)value[0], (uint8)(int)value[1], (uint8)(int)value[2], (uint8)(int)value[3]);
+	return Colour((uint8)((float)value[0]*255), (uint8)((float)value[1]*255), (uint8)((float)value[2]*255), (uint8)((float)value[3]*255));
 }
 
 void ColorParameter::setFloatRGBA(const float & r, const float & g, const float & b, const float & a)
@@ -76,20 +64,10 @@ void ColorParameter::setColor(const uint32 & _color, bool silentSet, bool force)
 void ColorParameter::setColor(const Colour &_color, bool silentSet, bool force)
 {
 	var colorVar;
-	if (mode == FLOAT)
-	{
-		colorVar.append(_color.getFloatRed());
-		colorVar.append(_color.getFloatGreen());
-		colorVar.append(_color.getFloatBlue());
-		colorVar.append(_color.getFloatAlpha());
-	}
-	else
-	{
-		colorVar.append(_color.getRed());
-		colorVar.append(_color.getGreen());
-		colorVar.append(_color.getBlue());
-		colorVar.append(_color.getAlpha());
-	}
+	colorVar.append(_color.getFloatRed());
+	colorVar.append(_color.getFloatGreen());
+	colorVar.append(_color.getFloatBlue());
+	colorVar.append(_color.getFloatAlpha());
 	
 	setValue(colorVar, silentSet, force);
 }
@@ -97,20 +75,10 @@ void ColorParameter::setColor(const Colour &_color, bool silentSet, bool force)
 void ColorParameter::setDefaultValue(const Colour& _color, bool doResetValue)
 {
 	var cVal = var();
-	if (mode == FLOAT)
-	{
-		cVal.append(_color.getFloatRed());
-		cVal.append(_color.getFloatGreen());
-		cVal.append(_color.getFloatBlue());
-		cVal.append(_color.getFloatAlpha());
-	}
-	else
-	{
-		cVal.append(_color.getRed());
-		cVal.append(_color.getGreen());
-		cVal.append(_color.getBlue());
-		cVal.append(_color.getAlpha());
-	}
+	cVal.append(_color.getFloatRed());
+	cVal.append(_color.getFloatGreen());
+	cVal.append(_color.getFloatBlue());
+	cVal.append(_color.getFloatAlpha());
 
 	Parameter::setDefaultValue(cVal, doResetValue);
 }

--- a/controllable/parameter/ColorParameter.h
+++ b/controllable/parameter/ColorParameter.h
@@ -17,11 +17,8 @@ class ColorParameter :
 {
 public:
 
-	enum Mode { UINT, FLOAT };
 	ColorParameter(const juce::String& niceName, const juce::String& description, const juce::Colour& initialColor = juce::Colours::black, bool enabled = true);
 	~ColorParameter();
-
-	Mode mode;
 
 	const juce::Colour getColor();
 	void setFloatRGBA(const float& r, const float& g, const float& b, const float& a);

--- a/script/Script.cpp
+++ b/script/Script.cpp
@@ -501,24 +501,23 @@ var Script::addColorParameterFromScript(const var::NativeFunctionArgs& args)
 	{
 		color = args.arguments[2];
 		while (color.size() < 4) color.append(color.size() < 3 ? 0 : 1);
-		for (int i = 0; i < color.size(); ++i) color[i] = (float)color[i] * 255;
 	}
 	else if (args.numArguments >= 5)
 	{
-		color.append((float)args.arguments[2] * 255);
-		color.append((float)args.arguments[3] * 255);
-		color.append((float)args.arguments[4] * 255);
-		color.append((float)args.numArguments >= 6 ? (float)args.arguments[5] * 255 : 255);
+		color.append((float)args.arguments[2]);
+		color.append((float)args.arguments[3]);
+		color.append((float)args.arguments[4]);
+		color.append((float)args.numArguments >= 6 ? (float)args.arguments[5] : 1.f);
 	}
 	else if (args.arguments[2].isInt() || args.arguments[2].isInt64())
 	{
-		color.append(((int)args.arguments[2] >> 24) & 0xFF);
-		color.append(((int)args.arguments[2] >> 16) & 0xFF);
-		color.append(((int)args.arguments[2] >> 8) & 0xFF);
-		color.append(((int)args.arguments[2]) & 0xFF);
+		color.append((float)(((int)args.arguments[2] >> 24) & 0xFF) / 255.f);
+		color.append((float)(((int)args.arguments[2] >> 16) & 0xFF) / 255.f);
+		color.append((float)(((int)args.arguments[2] >> 8) & 0xFF) / 255.f);
+		color.append((float)(((int)args.arguments[2]) & 0xFF) / 255.f);
 	}
 
-	Parameter* p = s->scriptParamsContainer->addColorParameter(args.arguments[0], args.arguments[1], Colour((uint8)(int)color[0], (uint8)(int)color[1], (uint8)(int)color[2], (uint8)(int)color[3]));
+	Parameter* p = s->scriptParamsContainer->addColorParameter(args.arguments[0], args.arguments[1], Colour((float)color[0], (float)color[1], (float)color[2], (float)color[3]));
 	p->isCustomizableByUser = true;
 	return p->getScriptObject();
 }


### PR DESCRIPTION
This PR must be compiled with the JUCE version from https://github.com/benkuper/JUCE/pull/1 and the **JUCE_FLOAT_COLOURS** option must be enabled in Projucer.

This PR simply makes a few tweaks to the ColorParameter class to avoid float values being rounded up.