### PR TITLE
Fix compilation error when compiling code with c++ 20 std with gcc

### DIFF
--- a/manager/BaseManager.h
+++ b/manager/BaseManager.h
@@ -21,8 +21,8 @@ class BaseManager :
 	public BaseItemListener
 {
 public:
-	BaseManager<T>(const juce::String& name);
-	virtual ~BaseManager<T>();
+	BaseManager(const juce::String& name);
+	virtual ~BaseManager();
 
 	juce::OwnedArray<T, juce::CriticalSection> items;
 	bool isClearing;
@@ -282,7 +282,7 @@ public:
 	static juce::var reorderItemsFromScript(const juce::var::NativeFunctionArgs& args);
 
 private:
-	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(BaseManager<T>)
+	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(BaseManager)
 };
 
 

--- a/manager/ui/BaseItemMinimalUI.h
+++ b/manager/ui/BaseItemMinimalUI.h
@@ -18,8 +18,8 @@ class BaseItemMinimalUI :
 	public juce::DragAndDropTarget
 {
 public:
-	BaseItemMinimalUI<T>(T* _item);
-	virtual ~BaseItemMinimalUI<T>();
+	BaseItemMinimalUI(T* _item);
+	virtual ~BaseItemMinimalUI();
 
 	T* item;
 	BaseItem* baseItem;

--- a/manager/ui/BaseItemUI.h
+++ b/manager/ui/BaseItemUI.h
@@ -21,8 +21,8 @@ class BaseItemUI :
 public:
 	enum Direction { NONE, VERTICAL, HORIZONTAL, ALL };
 
-	BaseItemUI<T>(T* _item, Direction resizeDirection = NONE, bool showMiniModeBT = false);
-	virtual ~BaseItemUI<T>();
+	BaseItemUI(T* _item, Direction resizeDirection = NONE, bool showMiniModeBT = false);
+	virtual ~BaseItemUI();
 
 	//LAYOUT
 	int margin;
@@ -127,7 +127,7 @@ public:
 
 
 private:
-	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(BaseItemUI<T>)
+	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(BaseItemUI)
 };
 
 

--- a/manager/ui/BaseManagerShapeShifterUI.h
+++ b/manager/ui/BaseManagerShapeShifterUI.h
@@ -16,7 +16,7 @@ class BaseManagerShapeShifterUI :
 	public ShapeShifterContent
 {
 public:
-	BaseManagerShapeShifterUI<M, T, U>(const juce::String &contentName, M * _manager, bool useViewport = true) :
+	BaseManagerShapeShifterUI(const juce::String &contentName, M * _manager, bool useViewport = true) :
 		BaseManagerUI<M, T, U>(contentName, _manager, useViewport),
 		ShapeShifterContent(this,contentName)
 	{
@@ -30,7 +30,7 @@ class BaseManagerShapeShifterViewUI :
 	public ShapeShifterContent
 {
 public:
-	BaseManagerShapeShifterViewUI<M, T, U>(const juce::String &contentName, M * _manager) :
+	BaseManagerShapeShifterViewUI(const juce::String &contentName, M * _manager) :
 		BaseManagerViewUI<M, T, U>(contentName, _manager),
 		ShapeShifterContent(this, contentName)
 	{

--- a/manager/ui/BaseManagerUI.h
+++ b/manager/ui/BaseManagerUI.h
@@ -36,7 +36,7 @@ class ManagerUIItemContainer :
 	public juce::Component
 {
 public:
-	ManagerUIItemContainer<M, T, U>(BaseManagerUI<M, T, U>* _mui) : mui(_mui) {};
+	ManagerUIItemContainer(BaseManagerUI<M, T, U>* _mui) : mui(_mui) {};
 	~ManagerUIItemContainer() {}
 
 	BaseManagerUI<M, T, U>* mui;
@@ -61,7 +61,7 @@ class BaseManagerUI :
 	public juce::TextEditor::Listener
 {
 public:
-	BaseManagerUI<M, T, U>(const juce::String& contentName, M* _manager, bool _useViewport = true);
+	BaseManagerUI(const juce::String& contentName, M* _manager, bool _useViewport = true);
 	virtual ~BaseManagerUI();
 
 	enum Layout { HORIZONTAL, VERTICAL, FREE };

--- a/manager/ui/BaseManagerViewUI.h
+++ b/manager/ui/BaseManagerViewUI.h
@@ -15,7 +15,7 @@ class BaseManagerViewUI :
 	public BaseManagerUI<M, T, U>
 {
 public:
-	BaseManagerViewUI<M, T, U>(const juce::String& contentName, M* _manager);
+	BaseManagerViewUI(const juce::String& contentName, M* _manager);
 	virtual ~BaseManagerViewUI();
 
 	bool canNavigate;


### PR DESCRIPTION
Specifying template arguments in the constructor/destructor declaration inside the templated class itself seems to cause compilation errors in gcc (version 11 and 12). Clang and MSVC compilers did not output errors with previous syntax.
Removing them allows the compilation under gcc to succeed.

It seems to be ok to remove them (see [here](https://en.cppreference.com/w/cpp/language/member_template) for doc about constructors/destructors syntax in templated classes). It would be nice to make sure that having them was not an intended special template black-magic thingy.