### PR TITLE
add check for an 'extendedType' field when creating an item from data

### DIFF
--- a/manager/BaseManager.h
+++ b/manager/BaseManager.h
@@ -382,6 +382,10 @@ T* BaseManager<T>::createItemFromData(juce::var data)
 {
 	if (managerFactory != nullptr)
 	{
+		juce::String extendedType = data.getProperty("extendedType", "");
+		if (extendedType != "") {
+			return managerFactory->create(managerFactory->getDefFromExtendedType(extendedType));
+		}
 		juce::String type = data.getProperty("type", "");
 		if (type.isEmpty()) return nullptr;
 		return managerFactory->create(type);

--- a/manager/Factory.h
+++ b/manager/Factory.h
@@ -210,6 +210,20 @@ public:
 		return nullptr;
 	}
 
+	virtual BaseFactoryDefinition<T>* getDefFromExtendedType(const juce::String& extendedType)
+	{
+		if (!extendedType.matchesWildcard("*/*", true)) return nullptr;
+
+		juce::String menuPath = extendedType.substring(0, extendedType.indexOf("/"));
+		juce::String type = extendedType.substring(extendedType.indexOf("/") + 1, extendedType.length());
+
+		for (auto& d : defs)
+		{
+			if (d->menuPath == menuPath && d->type == type) return d;
+		}
+		return nullptr;
+	}
+
 	virtual T* create(BaseFactoryDefinition<T> * def)
 	{
 		return def->create();


### PR DESCRIPTION
Add support to create objects with extended types (menu path + type), needed to properly create items where multiple factory definitions exists for a single type through the remote control.