### PR TITLE
WIP: add range to color parameters

### DIFF
--- a/controllable/parameter/ColorParameter.h
+++ b/controllable/parameter/ColorParameter.h
@@ -20,10 +20,14 @@ public:
 	ColorParameter(const juce::String& niceName, const juce::String& description, const juce::Colour& initialColor = juce::Colours::black, bool enabled = true);
 	~ColorParameter();
 
-	const juce::Colour getColor();
+	juce::Colour getColor() const;
 	void setFloatRGBA(const float& r, const float& g, const float& b, const float& a);
 	void setColor(const juce::uint32& _color, bool silentSet = false, bool force = false);
 	void setColor(const juce::Colour& _color, bool silentSet = false, bool force = false);
+
+	void setBounds(float _minR, float _minG, float _minB, float _minA, float _maxR, float _maxG, float _maxB, float _maxA);
+	void clearRange() override;
+	bool hasRange() const override;
 
 	void setDefaultValue(const juce::Colour& _color, bool doResetValue = true);
 
@@ -45,4 +49,6 @@ public:
 	virtual juce::String getTypeString() const override { return getTypeStringStatic(); }
 	static juce::String getTypeStringStatic() { return "Color"; }
 
+protected:
+	juce::var getCroppedValue(juce::var originalValue) override;
 };

--- a/controllable/parameter/FloatParameter.cpp
+++ b/controllable/parameter/FloatParameter.cpp
@@ -89,7 +89,7 @@ void FloatParameter::setValueInternal(var& val)
 	else Parameter::setValueInternal(val);
 }
 
-bool FloatParameter::hasRange()
+bool FloatParameter::hasRange() const
 {
 	return (double)minimumValue != (double)INT32_MIN && (double)maximumValue != (double)INT32_MAX;
 }

--- a/controllable/parameter/FloatParameter.h
+++ b/controllable/parameter/FloatParameter.h
@@ -41,7 +41,7 @@ public:
 
 	virtual void setValueInternal(juce::var& value) override;
 
-	virtual bool hasRange() override;
+	virtual bool hasRange() const override;
 
 	virtual juce::var getLerpValueTo(juce::var targetValue, float weight) override;
 	virtual void setWeightedValue(juce::Array<juce::var> values, juce::Array<float> weights) override;

--- a/controllable/parameter/IntParameter.cpp
+++ b/controllable/parameter/IntParameter.cpp
@@ -45,7 +45,7 @@ void IntParameter::setWeightedValue(Array<var> values, Array<float> weights)
 }
 
 
-bool IntParameter::hasRange()
+bool IntParameter::hasRange() const
 {
 	return (float)minimumValue != INT32_MIN || (float)maximumValue != INT32_MAX;
 

--- a/controllable/parameter/IntParameter.h
+++ b/controllable/parameter/IntParameter.h
@@ -28,7 +28,7 @@ public:
 	virtual void setWeightedValue(juce::Array<juce::var> values, juce::Array<float> weights) override;
 	juce::var getCroppedValue(juce::var originalValue) override;
 
-	virtual bool hasRange() override;
+	virtual bool hasRange() const override;
 
 	void setControlAutomation() override;
 

--- a/controllable/parameter/Parameter.cpp
+++ b/controllable/parameter/Parameter.cpp
@@ -194,7 +194,7 @@ void Parameter::setValue(var _value, bool silentSet, bool force, bool forceOverr
 }
 
 
-bool Parameter::isComplex()
+bool Parameter::isComplex() const
 {
 	return value.isArray();
 }
@@ -243,19 +243,15 @@ void Parameter::clearRange()
 
 	if (isComplex())
 	{
+		GenericScopedLock<SpinLock> lock(valueSetLock);
+		var minVal = var();
+		var maxVal = var();
+		for (int i = 0; i < value.size(); ++i)
 		{
-			GenericScopedLock<SpinLock> lock(valueSetLock);
-			var minVal = var();
-			var maxVal = var();
-			for (int i = 0; i < value.size(); ++i)
-			{
-				minVal.append(INT32_MIN);
-				maxVal.append(INT32_MAX);
-			}
-			minimumValue = minVal;
-			maximumValue = maxVal;
+			minVal.append(INT32_MIN);
+			maxVal.append(INT32_MAX);
 		}
-
+		setRange(minVal, maxVal);
 	}
 	else
 	{
@@ -263,7 +259,7 @@ void Parameter::clearRange()
 	}
 }
 
-bool Parameter::hasRange()
+bool Parameter::hasRange() const
 {
 	if (!canHaveRange) return false;
 	{
@@ -359,7 +355,7 @@ void Parameter::setNormalizedValue(const var& normalizedValue, bool silentSet, b
 	}
 }
 
-var Parameter::getNormalizedValue()
+var Parameter::getNormalizedValue() const
 {
 	if (type == BOOL) return (float)value;
 

--- a/controllable/parameter/Parameter.h
+++ b/controllable/parameter/Parameter.h
@@ -78,12 +78,12 @@ public:
 	//ColorStatus
 	juce::HashMap<juce::var, juce::Colour> colorStatusMap;
 
-	bool isComplex();
+	bool isComplex() const;
 	virtual juce::StringArray getValuesNames();
 
 	virtual void setRange(juce::var min, juce::var max);
 	virtual void clearRange();
-	virtual bool hasRange();
+	virtual bool hasRange() const;
 
 	bool isPresettable;
 	bool isOverriden;
@@ -113,7 +113,7 @@ public:
 	//For Number type parameters
 	void setUndoableNormalizedValue(const juce::var& oldNormalizedValue, const juce::var& newNormalizedValue);
 	void setNormalizedValue(const juce::var& normalizedValue, bool silentSet = false, bool force = false);
-	juce::var getNormalizedValue();
+	juce::var getNormalizedValue() const;
 
 	virtual bool setAttributeInternal(juce::String param, juce::var value) override;
 	virtual juce::StringArray getValidAttributes() const override;

--- a/controllable/parameter/ui/ColorParameterUI.cpp
+++ b/controllable/parameter/ui/ColorParameterUI.cpp
@@ -87,6 +87,43 @@ void ColorParameterUI::showEditWindowInternal()
 	colorEditor->addComponentListener(this);
 }
 
+void ColorParameterUI::showEditRangeWindowInternal()
+{
+	if (!parameter->isCustomizableByUser) return;
+
+	AlertWindow* nameWindow = new AlertWindow("Change color bounds", "Set new bounds for this parameter", AlertWindow::AlertIconType::NoIcon, this);
+
+	const String coordNames[4]{ "Red", "Green", "Blue", "Alpha" };
+
+	for (int i = 0; i < 4; ++i)
+	{
+		nameWindow->addTextEditor("minVal" + String(i), String((float)colorParam->minimumValue[i]), "Minimum " + coordNames[i]);
+		nameWindow->addTextEditor("maxVal" + String(i), String((float)colorParam->maximumValue[i]), "Maximum " + coordNames[i]);
+	}
+
+	nameWindow->addButton("OK", 1, KeyPress(KeyPress::returnKey));
+	nameWindow->addButton("Cancel", 0, KeyPress(KeyPress::escapeKey));
+
+	nameWindow->enterModalState(true, ModalCallbackFunction::create([this, nameWindow](int result)
+		{
+			if (result != 1) return;
+
+			float newMins[4];
+			float newMaxs[4];
+			for (int i = 0; i < 4; ++i)
+			{
+				newMins[i] = nameWindow->getTextEditorContents("minVal" + String(i)).getFloatValue();
+				newMaxs[i] = nameWindow->getTextEditorContents("maxVal" + String(i)).getFloatValue();
+			}
+			colorParam->setBounds(newMins[0], newMins[1], newMins[2], newMins[3],
+								  jmax(newMins[0], newMaxs[0]),
+								  jmax(newMins[1], newMaxs[1]),
+								  jmax(newMins[2], newMaxs[2]),
+								  jmax(newMins[3], newMaxs[3]));
+		}
+	), true);
+}
+
 void ColorParameterUI::componentBeingDeleted(Component& c)
 {
 	if (&c == colorEditor)

--- a/controllable/parameter/ui/ColorParameterUI.h
+++ b/controllable/parameter/ui/ColorParameterUI.h
@@ -33,6 +33,7 @@ public:
 	void mouseDownInternal(const juce::MouseEvent &e) override;
 
 	void showEditWindowInternal() override;
+	void showEditRangeWindowInternal() override;
 
 	void componentBeingDeleted(juce::Component &) override;
 

--- a/controllable/parameter/ui/ParameterUI.cpp
+++ b/controllable/parameter/ui/ParameterUI.cpp
@@ -209,6 +209,10 @@ void ParameterUI::addPopupMenuItems(PopupMenu* p)
 				rangeMenu.addItem(-72, "0 : 100");
 				rangeMenu.addItem(-73, "-100 : 100");
 			}
+			else if (parameter->type == Parameter::COLOR)
+			{
+				rangeMenu.addItem(-80, "Opaque");
+			}
 
 			if (parameter->type == Parameter::FLOAT || parameter->type == Parameter::INT)
 			{
@@ -313,6 +317,9 @@ void ParameterUI::handleMenuSelectedID(int id)
 	case -73:
 		if (parameter->type == Parameter::POINT2D) ((Point2DParameter*)parameter.get())->setBounds(-100, -100, 100, 100);
 		else ((Point3DParameter*)parameter.get())->setBounds(-100, -100, -100, 100, 100, 100);
+		break;
+	case -80:
+		((ColorParameter*)parameter.get())->setBounds(0.f, 0.f, 0.f, 1.f, 1.f, 1.f, 1.f, 1.f);
 		break;
 
 	default:


### PR DESCRIPTION
This must not be merged yet!

This PR adds ranges to color parameter.
My use case is to easily generate random colors within some constraints. I could write a script, but it feels better to just extend the existing range mechanism to colors and use it.

But RGB ranges are not meaningful most of the time. HSV ranges make much more sense! (e.g. I want bright and saturation colors)
Currently, a range is simply a min/max so the value can be clamped. For colors, I extended the concept, adding a "rangeMode" to "crop" according to a RGB or HSV range.

2 pitfalls:
- I had to override some range related methods and make get/setNormalizedValue virtual too.
- One cannot sync the range of 2 parameters as easily, because there is more to copy than min/maximumValue now. Also get/setRangeFromScript is not complete anymore.

I'm especially concerned about the 2nd, that's what I'd like to discuss.

This PR use a "rangeMode" enum attribute to the ColorParameter class. Parameter type must be tested for "color" in several places to support the new range completely, which is doable but not ideal.
An alternative approach is to add a generic "rangeMode" attribute to the Parameter class. It would be useless for all children except for color... But sync and get/setRangeFromScript could be supported from scratch. Also, maybe there is more use cases of a "rangeMode" for other types.
