### PR TITLE
fix: create parent folders if they do not exist

### DIFF
--- a/engine/EngineFileDocument.cpp
+++ b/engine/EngineFileDocument.cpp
@@ -173,6 +173,7 @@ Result Engine::saveDocument(const File& file) {
 	var data = getJSONData();
 
 	if (file.exists()) file.deleteFile();
+	file.create();	// recursively create parents create + empty file, beacause next line will not create parent dirs
 	std::unique_ptr<OutputStream> os(file.createOutputStream());
 	if (os == nullptr)
 	{


### PR DESCRIPTION
Fixes a bug when a file gets saved without the Documents/<AppName> folder existing. This can happen when there was never a file saved from the native UI.