### PR TITLE
fix remove button gets focus

### DIFF
--- a/manager/ui/BaseItemEditor.cpp
+++ b/manager/ui/BaseItemEditor.cpp
@@ -13,6 +13,7 @@ BaseItemEditor::BaseItemEditor(Array<BaseItem*> bi, bool isRoot) :
 	{
 		removeBT.reset(AssetManager::getInstance()->getRemoveBT());
 		removeBT->setWantsKeyboardFocus(false);
+		removeBT->setMouseClickGrabsKeyboardFocus(false);
 		addAndMakeVisible(removeBT.get());
 		removeBT->addListener(this);
 	}
@@ -23,6 +24,7 @@ BaseItemEditor::BaseItemEditor(Array<BaseItem*> bi, bool isRoot) :
 		{
 			duplicateBT.reset(AssetManager::getInstance()->getDuplicateBT());
 			duplicateBT->setWantsKeyboardFocus(false);
+			duplicateBT->setMouseClickGrabsKeyboardFocus(false);
 			addAndMakeVisible(duplicateBT.get());
 			duplicateBT->addListener(this);
 		}

--- a/manager/ui/BaseItemUI.h
+++ b/manager/ui/BaseItemUI.h
@@ -203,6 +203,8 @@ BaseItemUI<T>::BaseItemUI(T* _item, Direction _resizeDirection, bool showMiniMod
 	if (this->baseItem->userCanRemove)
 	{
 		removeBT.reset(AssetManager::getInstance()->getRemoveBT());
+		removeBT->setWantsKeyboardFocus(false);
+		removeBT->setMouseClickGrabsKeyboardFocus(false);
 		this->addAndMakeVisible(removeBT.get());
 		removeBT->addListener(this);
 	}


### PR DESCRIPTION
I had a lot of crashes in Chataigne 1.9.18b5 until I realized it randomly deletes active states, ongoing actions, etc. when pressing "Enter". That's because the remove button get the focus very easily!
I think it's new from 1.9.17 but I may be wrong.
