### PR TITLE
fix: compare text desciptions of keyPresses instead of keyCodes

### DIFF
--- a/manager/ui/BaseManagerViewUI.h
+++ b/manager/ui/BaseManagerViewUI.h
@@ -298,12 +298,12 @@ bool BaseManagerViewUI<M, T, U>::keyPressed(const juce::KeyPress& e)
 {
 	if (BaseManagerUI<M, T, U>::keyPressed(e)) return true;
 
-	if (e.getKeyCode() == juce::KeyPress::createFromDescription("f").getKeyCode())
+	if (e.getTextDescription() == juce::KeyPress::createFromDescription("f").getTextDescription())
 	{
 		frameView();
 		return true;
 	}
-	else if (e.getKeyCode() == juce::KeyPress::createFromDescription("h").getKeyCode())
+	else if (e.getTextDescription() == juce::KeyPress::createFromDescription("h").getTextDescription())
 	{
 		homeView();
 		return true;


### PR DESCRIPTION
There are inconsistencies between linux and windows regarding the keyCode values. It might be better to check the textDescriptions for a better cross-platform compatibility.

Those two lines seem to be the only ones where we compare character keys, not sure if there are issues on other keys. This fixes the issue with the "home" shortcut not working on linux.