### PR TITLE
AutomationUI rework for better performance

### DIFF
--- a/automation/parameter/ui/ParameterAutomationEditor.cpp
+++ b/automation/parameter/ui/ParameterAutomationEditor.cpp
@@ -16,7 +16,7 @@ ParameterAutomationEditor::ParameterAutomationEditor(ParameterAutomation * ppa) 
 
 	if (AutomationEditor * ae = dynamic_cast<AutomationEditor *>(automationEditor.get()))
 	{
-		ae->automationUI->autoAdaptViewRange = true;
+		ae->automationUI->keysUI.autoAdaptViewRange = true;
 	}
 	
 	setSize(100, automationEditor->getHeight());

--- a/automation/ui/AutomationEditor.cpp
+++ b/automation/ui/AutomationEditor.cpp
@@ -50,9 +50,9 @@ void AutomationEditor::resetAndBuild()
 		{
 			automationUI.reset(new AutomationUI(automation));
 
-			automationUI->bgColor = BG_COLOR;
-			automationUI->transparentBG = false;
-			automationUI->autoAdaptViewRange = true;
+			automationUI->keysUI.bgColor = BG_COLOR;
+			automationUI->keysUI.transparentBG = false;
+			automationUI->keysUI.autoAdaptViewRange = true;
 			addAndMakeVisible(automationUI.get());
 			automationUI->setViewRange(0, automation->length->floatValue());
 		}

--- a/automation/ui/AutomationMultiKeyTransformer.cpp
+++ b/automation/ui/AutomationMultiKeyTransformer.cpp
@@ -53,7 +53,7 @@ void AutomationMultiKeyTransformer::updateKeysFromBounds()
 	{
 		Point<int> localPos = getLocalBounds().getRelativePoint(keysRelativePositions[i].x, keysRelativePositions[i].y);
 		Point<int> timelinePos = aui->getLocalPoint(this, localPos);
-		float targetPos = aui->getPosForX(timelinePos.x);
+		float targetPos = aui->keysUI.getPosForX(timelinePos.x);
 		float targetVal = 1 - (timelinePos.y*1.f / aui->getHeight());
 		keysUI[i]->item->position->setValue(targetPos);
 		keysUI[i]->item->value->setValue(targetVal);


### PR DESCRIPTION
**This rework is decreasing CPU usage by 2-3 times when drawing AutomationUIs, like in a Chataigne Sequence.**

The magic behind it is basically splitting the different elements into separate layers, some of them cached by `setBufferedToImage(true)` to avoid repainting most of the UI.

This also fixes a few graphical glitches and the massive lag when scrolling thru layers or resizing a layer in Chataigne.

This does not break compatibility with latest main branches `juce_timeline` or `Chataigne` and can be imported with no further change.
It is possible (but unlikely) that a few minor changes will be necessary in other projects.
For example:
```C++
// From
automationUI->autoAdaptViewRange
// To
automationUI->keysUI.autoAdaptViewRange
```