### PR TITLE
Variable refresh rate for regulary updated UI elements

### DIFF
--- a/automation/ui/AutomationUI.h
+++ b/automation/ui/AutomationUI.h
@@ -106,7 +106,7 @@ public:
 
 class AutomationUI :
     public juce::Component,
-    public juce::Timer
+    public UITimerTarget
 {
 public:
     AutomationUI(Automation* manager);
@@ -117,7 +117,7 @@ public:
     AutomationUILayer overlay;
     AutomationUILayer background;
 
-    bool shouldRepaint;
+    bool shouldRepaintKeys;
     bool shouldRepaintOverlay;
 
     bool disableOverlayFill;
@@ -132,7 +132,10 @@ public:
     void paint(juce::Graphics& g) override;
     void resized() override;
 
-    void timerCallback() override;
+    void setRepaint(bool keys, bool overlay, bool background);
+
+    void paintOverChildren(juce::Graphics& g) override;
+    virtual void handlePaintTimerInternal() override;
 
     inline void setPreviewMode(bool value){keysUI.setPreviewMode(value);}
     inline void setViewRange(float start, float end){keysUI.setViewRange(start,end);}

--- a/controllable/parameter/gradient/ui/GradientColorManagerUI.cpp
+++ b/controllable/parameter/gradient/ui/GradientColorManagerUI.cpp
@@ -11,8 +11,8 @@
 
 GradientColorManagerUI::GradientColorManagerUI(GradientColorManager* manager) :
 	BaseManagerUI(manager->niceName, manager, false),
+	UITimerTarget(ORGANICUI_SLOW_TIMER, "GradientColorManagerUI"),
 	Thread("Colors " + String(manager->niceName)),
-	shouldRepaint(true),
 	shouldUpdateImage(true),
 	autoResetViewRangeOnLengthUpdate(false),
 	miniMode(false)
@@ -28,7 +28,6 @@ GradientColorManagerUI::GradientColorManagerUI(GradientColorManager* manager) :
 	manager->addAsyncCoalescedContainerListener(this);
 	addExistingItems();
 
-	startTimerHz(20);
 	startThread();
 }
 
@@ -88,6 +87,11 @@ void GradientColorManagerUI::paint(Graphics& g)
 		g.fillRect(r);
 	}
 	*/
+}
+
+void GradientColorManagerUI::paintOverChildren(Graphics& g)
+{
+	validatePaint();
 }
 
 void GradientColorManagerUI::resized()
@@ -300,11 +304,7 @@ void GradientColorManagerUI::run()
 
 }
 
-void GradientColorManagerUI::timerCallback()
+void GradientColorManagerUI::handlePaintTimerInternal()
 {
-	if (shouldRepaint)
-	{
-		repaint();
-		shouldRepaint = false;
-	}
+	repaint();
 }

--- a/controllable/parameter/gradient/ui/GradientColorManagerUI.h
+++ b/controllable/parameter/gradient/ui/GradientColorManagerUI.h
@@ -13,7 +13,7 @@
 class GradientColorManagerUI :
 	public BaseManagerUI<GradientColorManager, GradientColor, GradientColorUI>,
 	public ContainerAsyncListener,
-	public juce::Timer,
+	public UITimerTarget,
 	public juce::Thread
 
 {
@@ -21,7 +21,6 @@ public:
 	GradientColorManagerUI(GradientColorManager * manager);
 	~GradientColorManagerUI();
 
-	bool shouldRepaint;
 	bool shouldUpdateImage;
 
 	float viewStartPos;
@@ -41,6 +40,7 @@ public:
 	void setMiniMode(bool value);
 
 	void paint(juce::Graphics &g) override;
+	void paintOverChildren(juce::Graphics& g) override;
 
 	void resized() override;
 
@@ -64,5 +64,5 @@ public:
 
 	void run() override;
 	
-	void timerCallback() override;
+	void handlePaintTimerInternal() override;
 };

--- a/controllable/parameter/ui/ParameterUI.cpp
+++ b/controllable/parameter/ui/ParameterUI.cpp
@@ -20,7 +20,7 @@ std::function<void(ParameterUI*)> ParameterUI::customShowEditRangeWindowFunction
 
 ParameterUI::ParameterUI(Array<Parameter*> parameters, int paintTimerID) :
 	ControllableUI(Inspectable::getArrayAs<Parameter, Controllable>(parameters)),
-	UITimerTarget(paintTimerID),
+	UITimerTarget(paintTimerID, "ParameterUI"),
 	parameters(Inspectable::getWeakArray(parameters)),
 	parameter(parameters[0]),
 	setUndoableValueOnMouseUp(true),
@@ -141,6 +141,8 @@ void ParameterUI::paintOverChildren(Graphics& g)
 	}
 	break;
 	}
+
+	validatePaint();
 }
 
 void ParameterUI::handlePaintTimer()

--- a/ui/UITimers.cpp
+++ b/ui/UITimers.cpp
@@ -5,17 +5,15 @@ juce_ImplementSingleton(OrganicUITimers)
 
 OrganicUITimers::OrganicUITimers()
 {
-#if JUCE_MAC
-	startTimer(ORGANICUI_DEFAULT_TIMER, 1000 / 20); //20 fps drawing on mac
-	startTimer(ORGANICUI_SLOW_TIMER, 1000 / 15); //15 fps drawing on mac
-#else
 	startTimer(ORGANICUI_DEFAULT_TIMER, 1000 / 30); //30 fps drawing
 	startTimer(ORGANICUI_SLOW_TIMER, 1000 / 20); //20 fps drawing
-#endif
 
 	timerMap.set(ORGANICUI_DEFAULT_TIMER, {});
 	timerMap.set(ORGANICUI_SLOW_TIMER, {});
 
+#ifdef ORGANICUI_LOG_FPS_DEBUG
+	startTimer(ORGANICUI_FPS_TIMER, 1000); //1 fps log
+#endif
 }
 
 void OrganicUITimers::registerTarget(int timerID, UITimerTarget* ui)
@@ -30,9 +28,28 @@ void OrganicUITimers::unregisterTarget(int timerID, UITimerTarget* ui)
 
 void OrganicUITimers::timerCallback(int timerID)
 {
+#ifdef ORGANICUI_LOG_FPS_DEBUG
+	if(timerID == ORGANICUI_FPS_TIMER){
+		DBG("Default timer: " << fps[0] << "fps, slow timer: " << fps[1] << "fps");
+		fps.set(0, 0);
+		fps.set(1, 0);
+		return;
+	}
+#endif
+
 	if (timerMap.contains(timerID))
 	{
 		Array<WeakReference<UITimerTarget>> params = timerMap[timerID];
+
+		if(lastRepaintTimes.contains(timerID)){
+			juce::uint32 timeDiff = juce::Time::getMillisecondCounter() - lastRepaintTimes[timerID];
+
+			if(timeDiff < (getTimerInterval(timerID) * 13 / 10)) return;
+		}
+
+#ifdef ORGANICUI_LOG_FPS_DEBUG
+		fps.set(timerID, fps[timerID] + 1);
+#endif
 
 		for (auto& p : params)
 		{
@@ -47,8 +64,10 @@ void OrganicUITimers::timerCallback(int timerID)
 	}
 }
 
-UITimerTarget::UITimerTarget(int timerID) :
+UITimerTarget::UITimerTarget(int timerID, juce::String _name) :
 	shouldRepaint(false),
+	paintingAsked(false),
+	name(_name),
 	paintTimerID(timerID)
 {
 	if (paintTimerID >= 0) OrganicUITimers::getInstance()->registerTarget(paintTimerID, this);
@@ -65,6 +84,15 @@ UITimerTarget::~UITimerTarget()
 void UITimerTarget::handlePaintTimer()
 {
 	if (!shouldRepaint) return;
+	paintingAsked = true;
 	handlePaintTimerInternal();
 	shouldRepaint = false;
+}
+
+void UITimerTarget::validatePaint(){
+	if (paintingAsked && paintTimerID >= 0)
+	{
+		paintingAsked = false;
+		OrganicUITimers::getInstance()->lastRepaintTimes.set(paintTimerID, juce::Time::getMillisecondCounter());
+	}
 }

--- a/ui/UITimers.h
+++ b/ui/UITimers.h
@@ -3,18 +3,26 @@
 #define ORGANICUI_DEFAULT_TIMER 0
 #define ORGANICUI_SLOW_TIMER 1
 
+#define ORGANICUI_FPS_TIMER 99
+
+//#define ORGANICUI_LOG_FPS_DEBUG
+
 
 class UITimerTarget
 {
 public:
-	UITimerTarget(int timerID = -1);
+	UITimerTarget(int timerID = -1, juce::String _name = "");
 	virtual ~UITimerTarget();
 
 	int paintTimerID;
 	bool shouldRepaint;
+	bool paintingAsked;
+
+	juce::String name;
 
 	virtual void handlePaintTimer();
 	virtual void handlePaintTimerInternal() = 0;
+	virtual void validatePaint();
 
 
 	juce::WeakReference<UITimerTarget>::Master masterReference;
@@ -30,6 +38,10 @@ public:
 	~OrganicUITimers() {}
 
 	juce::HashMap<int, juce::Array<juce::WeakReference<UITimerTarget>>> timerMap;
+	juce::HashMap<int, juce::uint32> lastRepaintTimes;
+#ifdef ORGANICUI_LOG_FPS_DEBUG
+	juce::HashMap<int, int> fps;
+#endif
 
 	void registerTarget(int timerID, UITimerTarget* ui);
 	void unregisterTarget(int timerID, UITimerTarget* ui);


### PR DESCRIPTION
**This is allowing every `UITimerTarget` element to be adapted globally to a framerate that ensures the UI doesn´t slow down the engine.**
I also migrated all elements I could from `Timer` to `UITimerTarget` to take benefit from it.

This means in case of CPU overload, the UI might have a slower than 30fps refresh rate to allow for a much more responsive UI. 

Pausing a sequence in Chataigne for instance used to take 1-10 seconds to apply when CPU usage was too high, now it only takes a few hundres in worst case scenario (20 threads stress test running on same CPU core as Chataigne).

This change is not breaking any compatibility with previous usage, but in order to take full benefit from it, every element based on `UITimerTarget` should call the `validatePaint()` when finished painting. For example if the Component had children it is recommended to override this function :

```C++
void SequenceTimelineHeader::paintOverChildren(Graphics& g)
{
	validatePaint();
}
```