### PR TITLE
Undo fixes

### DIFF
--- a/automation/Automation.cpp
+++ b/automation/Automation.cpp
@@ -343,7 +343,11 @@ void Automation::setUnitSteps(float unitSteps)
 void Automation::addItemInternal(AutomationKey* k, var)
 {
 	k->position->unitSteps = positionUnitSteps;
-	if (positionUnitSteps > 0) k->position->setValue(k->position->getStepSnappedValueFor(k->position->floatValue()));
+	if (positionUnitSteps > 0)
+	{
+		k->position->setValue(k->position->getStepSnappedValueFor(k->position->floatValue()));
+		k->position->resetLastUndoValue();
+	}
 
 	if (!allowKeysOutside) k->position->setRange(0, length->floatValue());
 

--- a/automation/AutomationKey.cpp
+++ b/automation/AutomationKey.cpp
@@ -23,8 +23,10 @@ AutomationKey::AutomationKey(const float & _position, const float & _value) :
     value = addFloatParameter("Value", "The value of the key", 0);
 
     position->setValue(_position);
+    position->resetLastUndoValue();
     position->defaultUI = FloatParameter::TIME;
     value->setValue(_value);
+    value->resetLastUndoValue();
 
     easingType = addEnumParameter("Easing Type", "The type of interpolation to use");
     for (int i = 0; i < Easing::TYPE_MAX; i++) easingType->addOption(Easing::typeNames[i], (Easing::Type)i, false);

--- a/controllable/parameter/Parameter.cpp
+++ b/controllable/parameter/Parameter.cpp
@@ -237,6 +237,11 @@ void Parameter::setValue(juce::var _value, bool silentSet, bool force, bool forc
 	if (!silentSet) notifyValueChanged();
 }
 
+void Parameter::resetLastUndoValue()
+{
+	lastUndoValue = getValue().clone();
+}
+
 
 bool Parameter::isComplex() const
 {
@@ -770,6 +775,7 @@ bool Parameter::ParameterSetValueAction::undo()
 	}
 
 	p->setValue(oldValue);
+	p->lastUndoValue = oldValue;
 	return true;
 }
 

--- a/controllable/parameter/Parameter.h
+++ b/controllable/parameter/Parameter.h
@@ -111,6 +111,7 @@ public:
 	virtual void resetValue(bool silentSet = false);
 	virtual juce::Array<juce::UndoableAction*> setUndoableValue(juce::var newValue, bool onlyReturnAction = false, bool setSimilarSelected = false);
 	virtual void setValue(juce::var _value, bool silentSet = false, bool force = false, bool forceOverride = true, bool setSimilarSelected = false);
+	virtual void resetLastUndoValue();
 	virtual void setValueInternal(juce::var& _value);
 
 	virtual bool checkValueIsTheSame(juce::var newValue, juce::var oldValue); //can be overriden to modify check behavior


### PR DESCRIPTION
Fix `lastUndoValue` not beeing updated when undoing>
Added `Parameter::resetLastUndoValue()` function to be called when modifying the initial value of a Parameter **after** its creation

Also rebased on master