### PR TITLE
Call new virtual methods when a child controllable container is being…

### DIFF
--- a/controllable/ControllableContainer.cpp
+++ b/controllable/ControllableContainer.cpp
@@ -478,6 +478,8 @@ void ControllableContainer::addChildControllableContainer(ControllableContainer*
 		if (container->getWarningMessage().isNotEmpty()) warningChanged(container);
 	}
 
+	onChildContainerAdded();
+
 	controllableContainerListeners.call(&ControllableContainerListener::controllableContainerAdded, container);
 	queuedNotifier.addMessage(new ContainerAsyncEvent(ContainerAsyncEvent::ControllableContainerAdded, this, container));
 
@@ -512,6 +514,8 @@ void ControllableContainer::removeChildControllableContainer(ControllableContain
 	{
 		if (container->getWarningMessage().isNotEmpty()) warningChanged(container);
 	}
+
+	onChildContainerRemoved();
 
 	if (!Engine::mainEngine->isClearing)
 	{

--- a/controllable/ControllableContainer.h
+++ b/controllable/ControllableContainer.h
@@ -227,7 +227,9 @@ protected:
 	virtual void onControllableAdded(Controllable*) {};
 	virtual void onControllableRemoved(Controllable*) {};
 	virtual void onContainerParameterChangedAsync(Parameter*, const juce::var& /*value*/) {};
-	virtual void onWarningChanged(WarningTarget*) {}
+	virtual void onWarningChanged(WarningTarget*) {};
+	virtual void onChildContainerAdded() {};
+  virtual void onChildContainerRemoved() {};
 
 public:
 	DECLARE_INSPECTACLE_CRITICAL_LISTENER(ControllableContainer, controllableContainer);


### PR DESCRIPTION
I implemented two new virtual methods in the class ControllableContainer, which are onChildContainerAdded() and onChildContainerRemoved(). They are called respectively when a child container is being added or destroyed within the current controllable container. They are left empty in the mother class (they do nothing), so users may override them if needed.