### PR TITLE
Fix `isBetaVersion` flag on Engine

### DIFF
--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -35,7 +35,7 @@ Engine::Engine(const String& fileName, const String& fileExtension) :
 	isClearing(false)
 {
 	//skipControllableNameInAddress = true;
-	isBetaVersion = getAppVersion().endsWith("b");
+	isBetaVersion = getAppVersion().containsChar('b');
 	betaVersion = getBetaVersion(getAppVersion());
 
 	selectionManager.reset(new InspectableSelectionManager(true)); //selectionManager constructor


### PR DESCRIPTION
Maybe we need to fix the `isBetaVersion` boolean in the Engine to deal also with `X.X.XbXX` format and not only `X.X.Xb`.
I'm not totally sure about this PR, but it seems legit to me.

What do you think? 🤔