### PR TITLE
Sorting Stored Layouts by Filename

### DIFF
--- a/ui/shapeshifter/ShapeShifterManager.cpp
+++ b/ui/shapeshifter/ShapeShifterManager.cpp
@@ -452,6 +452,14 @@ PopupMenu ShapeShifterManager::getPanelsMenu()
 
 	Array<File> layoutFiles = getLayoutFiles();
 
+	std::sort(
+		layoutFiles.begin(),
+		layoutFiles.end(),
+		[](const File& a, const File& b) {
+			return a.getFileNameWithoutExtension() < b.getFileNameWithoutExtension();
+		}
+	);
+
 	//int specialIndex = layoutP.getNumItems() + 2; //+2 to have lockPanels
 	int li = 0;
 	for (auto& f : layoutFiles)


### PR DESCRIPTION
As per the JUCE documentation, the `findChildFiles` method [does not guarantee that the files will be returned in a consistent order](https://docs.juce.com/master/classFile.html#a5290046f7f78fffce0c4debd6668cbe5).  Because of this, the current behavior of Chataigne is such that the files loaded into the layout shortcuts for `CMD + 1`, `CMD + 2`, etc (e.g. on Mac), will actually be tied to a random layout.  This defeats the point of having a "shortcut" at all, given that it is likely to change on application reload.

This PR brings a deterministic ordering to the Layout shortcuts by adding a quick `sort` call on the names of the layout files.  A user can then use the filenames, themselves, to coerce desired layouts to specific shortcut keys.