### PR TITLE
Allow disabling some items from factory-generated popup menus

### DIFF
--- a/manager/Factory.h
+++ b/manager/Factory.h
@@ -25,6 +25,7 @@ public:
 	juce::String type;
 	juce::String menuPath;
 	juce::Image icon;
+	bool isEnabled = true;
 
 	BaseFactoryDefinition* addIcon(juce::Image icon)
 	{
@@ -153,7 +154,7 @@ public:
 
 			if (d->menuPath.isEmpty())
 			{
-				menu.addItem(itemID, d->type, true, false, d->icon);
+				menu.addItem(itemID, d->type, d->isEnabled, false, d->icon);
 				continue;
 			}
 
@@ -174,7 +175,7 @@ public:
 				subMenuIndex = subMenus.size() - 1;
 			}
 
-			subMenus[subMenuIndex]->addItem(itemID, d->type, true, false, d->icon);
+			subMenus[subMenuIndex]->addItem(itemID, d->type, d->isEnabled, false, d->icon);
 		}
 
 		for (int i = 0; i < subMenus.size(); ++i) menu.addSubMenu(subMenuNames[i], *subMenus[i]);


### PR DESCRIPTION
This can be useful to specify directly from the definition if some items should be disabled (= greyed out) depending on context
Default behavior is unchanged