### PR TITLE
Fix: Prevent infinite autosave loop on first change

### DIFF
--- a/engine/Engine.cpp
+++ b/engine/Engine.cpp
@@ -219,7 +219,7 @@ void Engine::timerCallback(int timerID)
 		{
 			if (GlobalSettings::getInstance()->autoSaveCurrentFile->boolValue()) if (getFile().existsAsFile()) saveDocument(getFile());
 			saveBackupDocument(autoSaveIndex);
-			autoSaveIndex = (autoSaveIndex + 1) % GlobalSettings::getInstance()->autoSaveCount->intValue();
+
 			startTimer(1, 60000 * GlobalSettings::getInstance()->autoSaveTime->intValue());
 		}
 	}

--- a/engine/Engine.h
+++ b/engine/Engine.h
@@ -45,6 +45,7 @@ public:
 
 	int autoSaveIndex;
 	juce::Time lastChangeTime;
+	bool isThereChangeToBackup = false; // true if there is real change to backup ( set to true on changed() methods )
 
 	virtual void changed() override;
 	void createNewGraph();

--- a/engine/EngineFileDocument.cpp
+++ b/engine/EngineFileDocument.cpp
@@ -28,6 +28,7 @@ void Engine::changed()
 {
 	FileBasedDocument::changed();
 	lastChangeTime = Time::getCurrentTime();
+	isThereChangeToBackup = true;
 	engineListeners.call(&EngineListener::fileChanged);
 	engineNotifier.addMessage(new EngineEvent(EngineEvent::FILE_CHANGED, this));
 }
@@ -245,10 +246,12 @@ juce::Result Engine::saveCopy()
 
 Result Engine::saveBackupDocument(int index)
 {
-	if (GlobalSettings::getInstance()->autoSaveOnChangeOnly->boolValue() && !hasChangedSinceSaved()) return Result::ok();
+
+	if (GlobalSettings::getInstance()->autoSaveOnChangeOnly->boolValue() && !isThereChangeToBackup ) {return Result::ok();}
 
 	if (!getFile().existsAsFile()) return Result::ok();
 
+	isThereChangeToBackup = false;// set to false, until changed() methods is call
 	String curFileName = getFile().getFileNameWithoutExtension();
 	File autoSaveDir = getFile().getParentDirectory().getChildFile(curFileName + "_autosave");
 	autoSaveDir.createDirectory();

--- a/engine/EngineFileDocument.cpp
+++ b/engine/EngineFileDocument.cpp
@@ -251,7 +251,6 @@ Result Engine::saveBackupDocument(int index)
 
 	if (!getFile().existsAsFile()) return Result::ok();
 
-	isThereChangeToBackup = false;// set to false, until changed() methods is call
 	String curFileName = getFile().getFileNameWithoutExtension();
 	File autoSaveDir = getFile().getParentDirectory().getChildFile(curFileName + "_autosave");
 	autoSaveDir.createDirectory();
@@ -274,6 +273,8 @@ Result Engine::saveBackupDocument(int index)
 
 	lastChangeTime = Time::getCurrentTime(); //needed to avoid detecting latest autosave as more recent than current file
 
+	isThereChangeToBackup = false; // set to false, until changed() methods is call
+	autoSaveIndex = (autoSaveIndex + 1) % GlobalSettings::getInstance()->autoSaveCount->intValue();
 	return Result::ok();
 }
 


### PR DESCRIPTION
### Summary
Fixes an issue where *autosave on change only* backup was triggered infinitely after the first change.
### Problem
The autosave system compared the current state to the last saved file.  
On the first detected change, it continuously triggered saves — since the comparison was always true until saving the document..

### Solution
A boolean flag now tracks whether a new user action has occurred.  (in the changed() methods)
Autosave will only trigger when an actual change is performed.

### Outcome

- Prevents infinite autosave loops
- Reduces unnecessary save operations