### PR TITLE
feat: Make Engine::checkAutoRestoreAutosave virtual

### DIFF
--- a/engine/Engine.h
+++ b/engine/Engine.h
@@ -73,7 +73,7 @@ public:
 	juce::File getLastDocumentOpened() override;
 	void setLastDocumentOpened(const juce::File& file) override;
 
-	bool checkAutoRestoreAutosave(const juce::File& originalFile, std::function<void(const juce::File&)> cancelCallback);
+	virtual bool checkAutoRestoreAutosave(const juce::File& originalFile, std::function<void(const juce::File&)> cancelCallback);
 	void restoreAutosave(const juce::File& originalFile, const juce::File& autosaveFile);
 
 	//    #if JUCE_MODAL_LOOPS_PERMITTED


### PR DESCRIPTION
Derived class can now add more conditions on when to show or not the autorestore popup