### PR TITLE
Revert "feat: OSCQuery LISTEN with initial feeback also sends feedback regarding the enabled status"

### DIFF
--- a/remotecontrol/OSCRemoteControl.cpp
+++ b/remotecontrol/OSCRemoteControl.cpp
@@ -829,7 +829,6 @@ void OSCRemoteControl::messageReceived(const String& id, const String& message)
 					if (sendFeedback)
 					{
 						sendOSCQueryFeedback(c);
-						sendOSCQueryStateFeedback(c);
 					}
 				}
 				else if (command == "IGNORE")


### PR DESCRIPTION
Reverts benkuper/juce_organicui#76

Turns out this this was not necessary, attribute ( == state ) changes are sent whether the parameter is listened to or not, so OSCQuery clients can stay in sync without this line