### PR TITLE
fix: Fix a deadlock that would occur when dynamically updating an enum parameter's option

### DIFF
--- a/controllable/parameter/EnumParameter.cpp
+++ b/controllable/parameter/EnumParameter.cpp
@@ -43,17 +43,19 @@ EnumParameter::~EnumParameter()
 
 EnumParameter* EnumParameter::addOption(String key, var data, bool selectIfFirstOption)
 {
-	GenericScopedLock lock(enumValues.getLock());
-	enumValues.add(new EnumValue(key, data));
-	if (enumValues.size() == 1 && selectIfFirstOption)
 	{
-		defaultValue = key;
-		setValue(key, true, false, false);
+		GenericScopedLock lock(enumValues.getLock());
+		enumValues.add(new EnumValue(key, data));
+		if (enumValues.size() == 1 && selectIfFirstOption)
+		{
+			defaultValue = key;
+			setValue(key, true, false, false);
+		}
+		updateArgDescription();
 	}
 
 	enumListeners.call(&EnumParameterListener::enumOptionAdded, this, key);
 	enumParameterNotifier.addMessage(new EnumParameterEvent(EnumParameterEvent::ENUM_OPTION_ADDED, this));
-	updateArgDescription();
 	return this;
 }
 
@@ -79,11 +81,14 @@ void EnumParameter::updateOption(int index, String key, var data, bool addIfNotT
 
 void EnumParameter::removeOption(String key)
 {
-	GenericScopedLock lock(enumValues.getLock());
-	enumValues.remove(getIndexForKey(key));
-	enumListeners.call(&EnumParameterListener::enumOptionRemoved, this, key);
+	{
+		GenericScopedLock lock(enumValues.getLock());
+		enumValues.remove(getIndexForKey(key));
+		updateArgDescription();
+	}
+
 	enumParameterNotifier.addMessage(new EnumParameterEvent(EnumParameterEvent::ENUM_OPTION_REMOVED, this));
-	updateArgDescription();
+	enumListeners.call(&EnumParameterListener::enumOptionRemoved, this, key);
 
 	if (getValueKey() == key) setValue("");
 }
@@ -101,9 +106,11 @@ void EnumParameter::setOptions(Array<EnumValue> options)
 
 void EnumParameter::clearOptions()
 {
-	GenericScopedLock lock(enumValues.getLock());
 	StringArray keysToRemove;
-	for (auto& ev : enumValues) keysToRemove.add(ev->key);
+	{
+		GenericScopedLock lock(enumValues.getLock());
+		for (auto& ev : enumValues) keysToRemove.add(ev->key);
+	}
 	for (auto& k : keysToRemove) removeOption(k);
 }
 


### PR DESCRIPTION
The deadlock is happening because of a misordering between `enumValues`'s mutex and `enumParameterNotifier.listener`'s one.

Here's a sample scenario using a random thread called 1, and the Message thread:

1 - In thread 1, an enum option is added with addOption. The thread acquires `enumValues`'s mutex then notifies async listeners. It releases the lock.
2 - The message thread decides it's a good time to dispach events. It acquires the listener's lock and starting notifying listeners, including `EnumParameterUI`
3 - In thread 1, the enum is updated again. The thread acquires `enumValues`'s lock, then tries to notify async listeners. It waits on the listener's mutex.
4 - In the message thread, the enum UI tries to acquire the `enumValues` mutex to update the display: https://github.com/benkuper/juce_organicui/blob/94d1ca74663c4568e6205b01edaf70eea27b67fc/controllable/parameter/ui/EnumParameterUI.cpp#L81 . The thread still holds the listeners' mutex

At that point, thread 1 holds `enumValues` 's mutex and waits for the listeners's one; 
and the message threads holds the listener's mutex and waits for the enumValues one


This PR solves this in a bunch of situations by releasing enumValues's mutex before notifying the listeners. It's not a definitive fix though, the situation can still happen if the mutex is locked beforehand for example, but I'm not sure how to handle that case properly
 

