### PR TITLE
Fix crashes happening when destroying a QueuedNotifier

### DIFF
--- a/helpers/QueuedNotifier.h
+++ b/helpers/QueuedNotifier.h
@@ -137,9 +137,30 @@ public:
     }
 
     // allow to stack all values or get oly last updated value
-    void addListener(Listener* newListener) { listeners.add(newListener); }
-    void addAsyncCoalescedListener(Listener* newListener) { lastListeners.add(newListener); }
-    void removeListener(Listener* listener) { listeners.remove(listener);lastListeners.remove(listener); }
+    void addListener(Listener* newListener) 
+    {
+		if (isBeingDestroyed.load(std::memory_order_acquire))
+			return;
+        
+        listeners.add(newListener); 
+    }
+
+    void addAsyncCoalescedListener(Listener* newListener) 
+    {
+		if (isBeingDestroyed.load(std::memory_order_acquire))
+			return;
+		
+        lastListeners.add(newListener);
+	}
+
+    void removeListener(Listener* listener) 
+    { 
+        if (isBeingDestroyed.load(std::memory_order_acquire))
+			return;
+        
+        listeners.remove(listener);
+        lastListeners.remove(listener); 
+    }
 
     void clearQueue()
     {


### PR DESCRIPTION
Introduced in https://github.com/benkuper/juce_organicui/commit/7103462489c2ab33f3ff15ab16e8836595453031