### PR TITLE
Fix OSCQuery feedback on Controllable rename

### DIFF
--- a/controllable/Controllable.cpp
+++ b/controllable/Controllable.cpp
@@ -126,7 +126,13 @@ void Controllable::setNiceName(const String& _niceName) {
 #if ORGANICUI_USE_WEBSERVER
 	if (!isFirstSetup)
 	{
-		if (OSCRemoteControl::getInstanceWithoutCreating() != nullptr && isAttachedToRoot()) OSCRemoteControl::getInstance()->sendPathNameChangedFeedback(oldControlAddress, getControlAddress());
+		if (OSCRemoteControl::getInstanceWithoutCreating() != nullptr && isAttachedToRoot())
+		{
+			// FULL_PATH *and* DESCRIPTION changed, so send both PATH_RENAMED then PATH_CHANGED feedback messages
+			const auto newControlAddress = getControlAddress();
+			OSCRemoteControl::getInstance()->sendPathNameChangedFeedback(oldControlAddress, newControlAddress);
+			OSCRemoteControl::getInstance()->sendPathChangedFeedback(newControlAddress); 
+		}
 	}
 #endif
 }

--- a/controllable/ControllableContainer.cpp
+++ b/controllable/ControllableContainer.cpp
@@ -401,7 +401,13 @@ void ControllableContainer::setNiceName(const String& _niceName)
 	controllableContainerListeners.call(&ControllableContainerListener::controllableContainerNameChanged, this);
 
 #if ORGANICUI_USE_WEBSERVER
-	if (OSCRemoteControl::getInstanceWithoutCreating() != nullptr && isAttachedToRoot()) OSCRemoteControl::getInstance()->sendPathNameChangedFeedback(oldControlAddress, getControlAddress());
+	if (OSCRemoteControl::getInstanceWithoutCreating() != nullptr && isAttachedToRoot())
+	{
+		// FULL_PATH *and* DESCRIPTION changed, so send both PATH_RENAMED then PATH_CHANGED feedback messages
+		const auto newControlAddress = getControlAddress();
+		OSCRemoteControl::getInstance()->sendPathNameChangedFeedback(oldControlAddress, newControlAddress);
+		OSCRemoteControl::getInstance()->sendPathChangedFeedback(newControlAddress);
+	}
 #endif
 
 	niceNameChanged();


### PR DESCRIPTION
OSCQuery server sends both PATH_RENAMED and PATH_CHANGED on Controllable niceName change, since both the path and the name have changed