### PR TITLE
Add ORGANICUI_USE_WEBBROWSER to allow builds without WebKit

### DIFF
--- a/dashboard/DashboardIFrameItem.cpp
+++ b/dashboard/DashboardIFrameItem.cpp
@@ -38,5 +38,9 @@ var DashboardIFrameItem::getItemParameterFeedback(Parameter* p)
 
 DashboardItemUI* DashboardIFrameItem::createUI()
 {
+	#if ORGANICUI_USE_WEBBROWSER
 	return new DashboardIFrameItemUI(this);
+	#else
+	return nullptr;
+	#endif
 }

--- a/dashboard/ui/DashboardIFrameItemUI.cpp
+++ b/dashboard/ui/DashboardIFrameItemUI.cpp
@@ -7,7 +7,7 @@
 
   ==============================================================================
 */
-
+#if ORGANICUI_USE_WEBBROWSER
 #include "JuceHeader.h"
 
 DashboardIFrameItemUI::DashboardIFrameItemUI(DashboardIFrameItem* item) :
@@ -72,3 +72,4 @@ void DashboardIFrameItemUI::controllableFeedbackUpdateInternal(Controllable* c)
 	DashboardItemUI::controllableFeedbackUpdateInternal(c);
 	if (c == iFrameItem->url) web.goToURL(iFrameItem->url->stringValue());
 }
+#endif

--- a/dashboard/ui/DashboardIFrameItemUI.h
+++ b/dashboard/ui/DashboardIFrameItemUI.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#if ORGANUI_USE_WEBBROWSER
 class DashboardIFrameItemUI :
     public DashboardItemUI
 {
@@ -33,3 +34,4 @@ public:
 
     void controllableFeedbackUpdateInternal(Controllable*) override;
 };
+#endif

--- a/juce_organicui.h
+++ b/juce_organicui.h
@@ -66,6 +66,13 @@
 #define ORGANICUI_USE_WEBSERVER 0
 #endif
 
+/** Config: ORGANICUI_USE_WEBBROWSER
+	Mirroring the option from juce_gui_extra, to avoid problems with webkit2gtk
+*/
+#ifndef ORGANICUI_USE_WEBBROWSER
+#define ORGANICUI_USE_WEBBROWSER JUCE_WEB_BROWSER
+#endif
+
 /** Config: ORGANICUI_USE_DASHBOARDPANEL
 	Enables the use of the DashboardPanel
 */


### PR DESCRIPTION
This adds an ORGANICUI_USE_WEBBROWSER configuration flag so OrganicUI can be built without JUCE  WebBrowserComponent/WebKit support.

The flag defaults to JUCE_WEB_BROWSER when available, preserving existing behavior by default.

When ORGANICUI_USE_WEBBROWSER=0, iframe/browser-specific dashboard code is excluded from compilation. This allows projects that do not use iframe items to build with JUCE_WEB_BROWSER=0, avoiding WebKitGTK requirements on Linux.

Tested on Linux Mint 22 with:
- JUCE_WEB_BROWSER=0
- ORGANICUI_USE_WEBBROWSER=0 (default set to JUCE_WEB_BROWSER)