### PR TITLE
stringDecimals in Slider

### DIFF
--- a/controllable/parameter/ui/FloatSliderUI.cpp
+++ b/controllable/parameter/ui/FloatSliderUI.cpp
@@ -21,7 +21,11 @@ FloatSliderUI::FloatSliderUI(Array<Parameter*> parameters) :
 	assignOnMousePosDirect = false;
 	changeParamOnMouseUpOnly = false;
 	orientation = HORIZONTAL;
-
+	// set the slider to stringDecimals of the parameter if floatParameter
+	if (auto* floatParam = dynamic_cast<FloatParameter*>(parameter.get()))
+	{
+		fixedDecimals = floatParam->stringDecimals;
+	}
 	setWantsKeyboardFocus(true);
 	ParameterUI::setNextFocusOrder(this);
 


### PR DESCRIPTION
The number of digits for SliderUI was harcoded to 3, it will now look up in the related floatParameter (if applicable) for the wanted precision.