### PR TITLE
Fix typo in macro name preventing compilation

### DIFF
--- a/dashboard/ui/DashboardIFrameItemUI.h
+++ b/dashboard/ui/DashboardIFrameItemUI.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#if ORGANUI_USE_WEBBROWSER
+#if ORGANICUI_USE_WEBBROWSER
 class DashboardIFrameItemUI :
     public DashboardItemUI
 {


### PR DESCRIPTION
?

introduced in: https://github.com/benkuper/juce_organicui/commit/412955d280e37c0bf0c8ab9f77d1d1e74d662c46