### PR TITLE
Prevent setting an EnumParameter value to an non-existent option

### DIFF
--- a/controllable/parameter/EnumParameter.cpp
+++ b/controllable/parameter/EnumParameter.cpp
@@ -478,3 +478,15 @@ DashboardItem* EnumParameter::createDashboardItem()
 {
 	return new DashboardEnumParameterItem(this);
 }
+
+void EnumParameter::setValueInternal(juce::var& key) 
+{
+	// If the set value does not exist as an option, reset to default
+	if (getIndexForKey(key.toString()) == -1)
+	{
+		Parameter::setValueInternal(defaultValue);
+		return;
+	}
+
+	Parameter::setValueInternal(key);
+}

--- a/controllable/parameter/EnumParameter.h
+++ b/controllable/parameter/EnumParameter.h
@@ -113,4 +113,6 @@ public:
 
 private:
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EnumParameter)
+
+	void setValueInternal(juce::var& data) override;
 };


### PR DESCRIPTION
Fallback to the default value if attempted

I don't think this breaks anything, but we can also add an option if you prefer