### PR TITLE
Pass warning details with async warning event instead of a ref to a controller to avoid threading safety issues

### DIFF
--- a/remotecontrol/OSCRemoteControl.cpp
+++ b/remotecontrol/OSCRemoteControl.cpp
@@ -663,13 +663,34 @@ void OSCRemoteControl::connectionOpened(const String& id)
 	remoteControlListeners.call(&RemoteControlListener::clientConnected, id);
 	feedbackMap.set(id, Array<Controllable*>()); // Reset feedbacks
 
+	// Send all existing persistent warnings
 	for (auto& wt : WarningReporter::getInstance()->targets)
 	{
 		if (wt == nullptr || wt.wasObjectDeleted())
 		{
 			continue;
 		}
-		sendPersistentWarningFeedback(wt);
+
+		String message = wt->getWarningMessage();
+		String address = "";
+		String name = "";
+		if (Controllable* c = dynamic_cast<Controllable*>(wt.get()))
+		{
+			name = c->niceName;
+			address = c->getControlAddress();
+		}
+		else if (ControllableContainer* cc = dynamic_cast<ControllableContainer*>(wt.get()))
+		{
+			name = cc->niceName;
+			address = cc->getControlAddress();
+		}
+		else
+		{
+			continue;
+		}
+
+		// TODO: Send each warning (by ID) individually
+		sendPersistentWarningFeedback(address, name, message);
 	}
 }
 
@@ -1042,57 +1063,30 @@ void OSCRemoteControl::sendLogFeedback(const String& type, const String& source,
 	server->send(JSON::toString(msg));
 }
 
-void OSCRemoteControl::sendPersistentWarningFeedback(WeakReference<WarningTarget> wt, String address, WarningReporter::WarningReporterEvent::Type type)
+void OSCRemoteControl::sendPersistentWarningFeedback(const String& emitterAddress, const String& warningID, const juce::String& warningMessage)
 {
+	jassert(emitterAddress.isNotEmpty());
+
 	if (server == nullptr)
 	{
 		return;
 	}
-	if (wt == nullptr || wt.wasObjectDeleted())
-	{
-		return;
-	}
+
 	if (Engine::mainEngine != nullptr && Engine::mainEngine->isClearing)
 	{
 		return;
 	}
 
-	String path = address;
-	String name;
-	if (Controllable* c = dynamic_cast<Controllable*>(wt.get()))
-	{
-		name = c->niceName;
-		if (path.isEmpty())
-		{
-			path = c->getControlAddress();
-		}
-	}
-	else if (ControllableContainer* cc = dynamic_cast<ControllableContainer*>(wt.get()))
-	{
-		name = cc->niceName;
-		if (path.isEmpty())
-		{
-			path = cc->getControlAddress();
-		}
-	}
-
-	if (path.isEmpty())
-	{
-		return;
-	}
-
-	String wMessage = type == WarningReporter::WarningReporterEvent::Type::WARNING_REGISTERED ? wt->getWarningMessage() : "";
-
+	var data(new DynamicObject());
+	data.getDynamicObject()->setProperty("source", emitterAddress);
+	data.getDynamicObject()->setProperty("id", warningID);
+	data.getDynamicObject()->setProperty("message", warningMessage);
+	// TODO: Send the event type as well so clients can decide how to handle them
+	
 	var msg(new DynamicObject());
 	msg.getDynamicObject()->setProperty("COMMAND", "WARNING");
-	var data(new DynamicObject());
-	data.getDynamicObject()->setProperty("source", path);
-	if (name.isNotEmpty())
-	{
-		data.getDynamicObject()->setProperty("name", name);
-	}
-	data.getDynamicObject()->setProperty("message", wMessage);
 	msg.getDynamicObject()->setProperty("DATA", data);
+	
 	server->send(JSON::toString(msg));
 }
 
@@ -1237,7 +1231,12 @@ void OSCRemoteControl::sendOSCQueryFeedbackTo(const OSCMessage& m, StringArray i
 
 void OSCRemoteControl::newMessage(const WarningReporter::WarningReporterEvent& e)
 {
-	sendPersistentWarningFeedback(e.target, e.targetAddress, e.type);
+	if (e.targetAddress.isEmpty())
+	{
+		return;
+	}
+
+	sendPersistentWarningFeedback(e.targetAddress, e.warningID, e.message);
 }
 
 #endif

--- a/remotecontrol/OSCRemoteControl.h
+++ b/remotecontrol/OSCRemoteControl.h
@@ -121,7 +121,7 @@ public:
 
 	void newMessage(const CustomLogger::LogEvent& e) override;
 	void sendLogFeedback(const juce::String& type, const juce::String& source, const juce::String& message);
-	void sendPersistentWarningFeedback(juce::WeakReference<WarningTarget> wt, juce::String address = juce::String(), WarningReporter::WarningReporterEvent::Type type = WarningReporter::WarningReporterEvent::WARNING_REGISTERED);
+	void sendPersistentWarningFeedback(const juce::String& address, const juce::String& warningID, const juce::String& warningMessage);
 	void newMessage(const WarningReporter::WarningReporterEvent& e) override;
 
 #endif

--- a/warning/WarningReporter.cpp
+++ b/warning/WarningReporter.cpp
@@ -27,7 +27,7 @@ void WarningReporter::clear()
 	targets.clear();
 }
 
-void WarningReporter::registerWarning(WeakReference<WarningTarget> target)
+void WarningReporter::registerWarning(WeakReference<WarningTarget> target, const String& warningID, const String& warningMessage)
 {
 	if (Engine::mainEngine->isClearing) return;
 	GenericScopedLock lock(targets.getLock());
@@ -39,10 +39,10 @@ void WarningReporter::registerWarning(WeakReference<WarningTarget> target)
 	else if (ControllableContainer* cc = dynamic_cast<ControllableContainer*>(target.get())) targetAddressMap.set(target, cc->getControlAddress());
 
 	if (Inspectable* i = dynamic_cast<Inspectable*>(target.get())) i->addInspectableListener(this);
-	warningReporterNotifier.addMessage(new WarningReporterEvent(WarningReporterEvent::WARNING_REGISTERED, target, targetAddressMap[target]));
+	warningReporterNotifier.addMessage(new WarningReporterEvent(WarningReporterEvent::WARNING_REGISTERED, target, targetAddressMap[target], warningID, warningMessage));
 }
 
-void WarningReporter::unregisterWarning(WeakReference<WarningTarget> target)
+void WarningReporter::unregisterWarning(WeakReference<WarningTarget> target, const String& warningID)
 {
 	if (Engine::mainEngine->isClearing && target != Engine::mainEngine) return;
 	GenericScopedLock lock(targets.getLock());
@@ -50,10 +50,9 @@ void WarningReporter::unregisterWarning(WeakReference<WarningTarget> target)
 	if (target == nullptr || target.wasObjectDeleted()) return;
 	targets.removeAllInstancesOf(target);
 	String address = targetAddressMap.contains(target) ? targetAddressMap[target] : String();
-	warningReporterNotifier.addMessage(new WarningReporterEvent(WarningReporterEvent::WARNING_UNREGISTERED, target, targetAddressMap[target]));
+	warningReporterNotifier.addMessage(new WarningReporterEvent(WarningReporterEvent::WARNING_UNREGISTERED, target, targetAddressMap[target], warningID, ""));
 
 	targetAddressMap.remove(target);
-
 }
 
 void WarningReporter::fileLoaded()
@@ -66,5 +65,5 @@ void WarningReporter::fileLoaded()
 
 void WarningReporter::inspectableDestroyed(Inspectable* i)
 {
-	unregisterWarning(i);
+	unregisterWarning(i, WarningTarget::warningAllId);
 }

--- a/warning/WarningReporter.h
+++ b/warning/WarningReporter.h
@@ -25,8 +25,8 @@ public:
 
 	void clear();
 
-	void registerWarning(juce::WeakReference<WarningTarget>);
-	void unregisterWarning(juce::WeakReference<WarningTarget>);
+	void registerWarning(juce::WeakReference<WarningTarget>, const juce::String& warningID, const juce::String& warningMessage);
+	void unregisterWarning(juce::WeakReference<WarningTarget>, const juce::String& warningID);
 
 	void fileLoaded() override;
 
@@ -39,12 +39,15 @@ public:
 	public:
 		enum Type { WARNING_REGISTERED, WARNING_UNREGISTERED };
 
-		WarningReporterEvent(Type t, juce::WeakReference<WarningTarget> target, const juce::String& address = juce::String()) :
-			type(t), target(target), targetAddress(address) {}
+		WarningReporterEvent(Type t, juce::WeakReference<WarningTarget> target, const juce::String& address, const juce::String& _warningID, const juce::String& _warningMessage) :
+			type(t), target(target), targetAddress(address), warningID(_warningID), message(_warningMessage) {}
 
 		Type type;
-		juce::WeakReference<WarningTarget> target;
+		juce::WeakReference<WarningTarget> target; // TODO: Dangerous, the target might be destroyed before the listeners are notified
+
 		juce::String targetAddress;
+		juce::String warningID;
+		juce::String message;
 	};
 
 	QueuedNotifier<WarningReporterEvent> warningReporterNotifier;

--- a/warning/WarningTarget.cpp
+++ b/warning/WarningTarget.cpp
@@ -35,7 +35,7 @@ void WarningTarget::setWarningMessage(const String& message, const String& id, b
 		if (message.isEmpty()) return;
 	}
 
-	if (warningMessage.size() == 0) WarningReporter::getInstance()->unregisterWarning(this);
+	if (warningMessage.size() == 0) WarningReporter::getInstance()->unregisterWarning(this, id);
 
 	if (log && Engine::mainEngine != nullptr && !Engine::mainEngine->isLoadingFile && !Engine::mainEngine->isClearing)
 	{
@@ -50,7 +50,7 @@ void WarningTarget::setWarningMessage(const String& message, const String& id, b
 	if (!message.isEmpty())
 	{
 		warningMessage.set(id, message);
-		WarningReporter::getInstance()->registerWarning(this);
+		WarningReporter::getInstance()->registerWarning(this, id, message);
 	}
 
 	notifyWarningChanged();
@@ -77,7 +77,7 @@ void WarningTarget::unregisterWarningNow()
 			if (!WarningReporter::getInstance()->targets.contains(this)) return;
 
 			MessageManagerLock mmLock;
-			WarningReporter::getInstance()->unregisterWarning(this);
+			WarningReporter::getInstance()->unregisterWarning(this, warningAllId);
 		}
 	}
 


### PR DESCRIPTION
Also changes the RemoteControl message to add warning ID and remove name (name can be retrieved by the client using the address)